### PR TITLE
docs: typo in object definition

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ generateGraphQL({ options }).then(
           Query: queryResolvers,
           Mutation: mutationResolvers,
         }
-      });
+      }),
       subscriptions: {
         keepAlive: 1000,
       },


### PR DESCRIPTION
This probably is the tiniest PR of github.

There is a semicolon where there should be a comma.